### PR TITLE
The Ass Driver (and removes the no exosuit conditional on superfart blasts)

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -700,18 +700,20 @@
 						if(do_after(usr,usr,30))
 							visible_message("<span class = 'warning'><b>[name]</b> unleashes a [pick("tremendous","gigantic","colossal")] fart!</span>","<span class = 'warning'>You hear a [pick("tremendous","gigantic","colossal")] fart.</span>")
 							playsound(location, 'sound/effects/superfart.ogg', 50, 0)
-							if(!wearing_suit)
-								for(var/mob/living/V in view(src,aoe_range))
-									if(!airborne_can_reach(location,get_turf(V),aoe_range))
-										continue
-									shake_camera(V,10,5)
-									if (V == src)
-										continue
-									to_chat(V, "<span class = 'danger'>You're sent flying!</span>")
-									V.Knockdown(5) // why the hell was this set to 12 christ
-									step_away(V,location,15)
-									step_away(V,location,15)
-									step_away(V,location,15)
+							for(var/mob/living/V in view(src,aoe_range))
+								if(!airborne_can_reach(location,get_turf(V),aoe_range))
+									continue
+								shake_camera(V,10,5)
+								if (V == src)
+									continue
+								to_chat(V, "<span class = 'danger'>You're sent flying!</span>")
+								V.Knockdown(5) // why the hell was this set to 12 christ
+								step_away(V,location,15)
+								step_away(V,location,15)
+								step_away(V,location,15)
+							if (istype(usr.loc,/turf/space))
+								to_chat(usr, "<span class = 'notice'>The gastrointestinal blast sends you careening through space!</span>")
+								throw_at(get_edge_target_turf(usr, dir), 5, 5)
 						else
 							to_chat(usr, "<span class = 'notice'>You were interrupted and couldn't fart! Rude!</span>")
 


### PR DESCRIPTION
-successfully superfarting on a space tile will launch you mass driver style in the direction you are facing.
-removes the condition that you must not be wearing an exosuit in order to stun and launch people with the superfart (I can revert this if people aren't happy with it, superfart is criminally underpowered imo, so I figured a small buff would do it some good).

![the_ass_driver](https://user-images.githubusercontent.com/25192877/28435850-96ba5640-6d49-11e7-94b3-6a9794d2a9fc.gif)

:cl:
rscadd: A recent breakthrough in the study of genetically-enhanced gastrointestinal-emissions has opened the way to several new opportunities in the field of space propulsion and travel. Ask your local geneticist today!